### PR TITLE
Fix greedy tooltip regex consuming text past first closing paren

### DIFF
--- a/library.js
+++ b/library.js
@@ -3,7 +3,7 @@
 const slugify = require.main.require('./src/slugify');
 
 const textHeaderRegex = /<p dir="auto">#([a-zA-Z0-9-]*)\((.*)\)<\/p>/g;
-const tooltipRegex = /(<code.*>*?[^]<\/code>)|°(.*)°\((.*)\)/g;
+const tooltipRegex = /(<code.*>*?[^]<\/code>)|°([^°]*)°\(([^)]*)\)/g;
 
 const codeTabRegex = /(?:<p dir="auto">={3}group<\/p>\n)((?:<pre><code class=".+">[^]*?<\/code><\/pre>\n){2,})(?:<p dir="auto">={3}<\/p>)/g;
 const langCodeRegex = /<code class="(.+)">/;


### PR DESCRIPTION
## The bug

`tooltipRegex` uses `.*` (greedy) for both the display-text and tooltip-text captures, so it runs to the last `°` / `)` on the line rather than the first. When a user follows a bubble with another parenthesized phrase on the same line, the tooltip swallows the gap.

Repro:

```
°°(tooltip text) (something else)
```

Renders today as:

```html
<i class="fa fa-info-circle extended-markdown-tooltip" title="tooltip text) (something else"></i>
```

Expected:

```html
<i class="fa fa-info-circle extended-markdown-tooltip" title="tooltip text"></i> (something else)
```

The reason a newline after the bubble appears to "fix" the issue is that `.` does not cross `\n` in JS by default, so an `Enter` after the closing `)` truncates the match early.

Reproduced against NodeBB 4.12.0 with extended-markdown 2.1.1.

## The fix

Replace the two `.*` captures with bounded character classes:

```diff
-const tooltipRegex = /(<code.*>*?[^]<\/code>)|°(.*)°\((.*)\)/g;
+const tooltipRegex = /(<code.*>*?[^]<\/code>)|°([^°]*)°\(([^)]*)\)/g;
```

- **display text → `[^°]*`** — cannot cross the bubble's own closing `°`. As a bonus, this also fixes the case of two adjacent bubbles on one line eating each other, e.g. `°word°(tip) text °other°(tip2)`.
- **tooltip text → `[^)]*`** — stops at the first `)`, the literal terminator.

Trade-off: a literal `)` can no longer appear inside the tooltip text. It couldn't be used reliably before either (the existing code matched the last `)` on the line, so any inner `)` already split the match arbitrarily depending on what followed), so this is not a real regression. If escaping is wanted down the road, `[^)]` can be relaxed to allow `\)` and the replace callback can strip the backslash.

## Tests / verified scenarios

Verified manually after applying the patch:

| input | before | after |
|---|---|---|
| `°°(tip) (extra)` | title="tip) (extra", extra consumed | title="tip", `(extra)` rendered as plain text ✓ |
| `°word°(tip) °other°(tip2)` | one merged bubble | two separate bubbles ✓ |
| `°°(tip)` | unchanged | unchanged ✓ |
| `°°(tip)` followed by newline + `(extra)` | already worked | still works ✓ |
